### PR TITLE
fix: rename emacs-official to -unofficial

### DIFF
--- a/_data/blogs.yml
+++ b/_data/blogs.yml
@@ -188,7 +188,7 @@ The Software Blogs:
   - accounts:
     - tumblr@ed-official
   - accounts:
-    - tumblr@emacs-official
+    - tumblr@emacs-unofficial
     comment: the ultimate editor
     sub_blogs:
       - accounts:


### PR DESCRIPTION
A long while ago, emacs-official was renamed to emacs-unofficial. This PR makes the list reflect that change.

It seems that since the rename, someone else made a emacs-official blog, but that has been inactive for almost a year with only 3 posts, so I doubt someone would complain.

(also adds a newline character at the end of the file, as POSIX standard mandates and all the text editors I have enforce)